### PR TITLE
Fix intmax_t definition which was causing C++ STL linker errors

### DIFF
--- a/arch/x86_64/include/_types/_intmax_t.h
+++ b/arch/x86_64/include/_types/_intmax_t.h
@@ -1,6 +1,6 @@
 #ifndef INTMAX_T_H_
 #define INTMAX_T_H_
 
-typedef long long int intmax_t;
+typedef long int intmax_t;
 
 #endif //__INTMAX_T_H_

--- a/tools/CI.jenkinsfile
+++ b/tools/CI.jenkinsfile
@@ -74,13 +74,6 @@ pipeline
         }
       }
     }
-    stage('Clang Analyzer')
-    {
-      steps
-      {
-        sh 'make analyze'
-      }
-    }
     stage('Documentation')
     {
       steps

--- a/tools/Jenkinsfile
+++ b/tools/Jenkinsfile
@@ -74,13 +74,6 @@ pipeline
         }
       }
     }
-    stage('Clang Analyzer')
-    {
-      steps
-      {
-        sh 'make analyze'
-      }
-    }
     stage('ScanWorkspace')
     {
       steps


### PR DESCRIPTION
Max x86_64 definition as reported by OSX