### PR TITLE
Resolve STL I definition problems

### DIFF
--- a/include/complex.h
+++ b/include/complex.h
@@ -1,0 +1,6 @@
+#ifndef COMPLEX_H__
+#define COMPLEX_H__
+
+#include <openlibm_complex.h>
+
+#endif // COMPLEX_H__

--- a/include/math.h
+++ b/include/math.h
@@ -5,7 +5,8 @@
 extern "C" {
 #endif
 
-#include <openlibm.h>
+#include <openlibm_fenv.h>
+#include <openlibm_math.h>
 
 #ifdef FLT_EVAL_METHOD
 #if FLT_EVAL_METHOD == 0


### PR DESCRIPTION
Don't include openlibm.h in math.h, as it's pulling in complex number definitions and messing things up.
We instead directly include the fenv and math headers.

We also created a new complex.h header which includes the openlibm definitions
