### PR TITLE
Architecture update: native support

### DIFF
--- a/arch/aarch64/meson.build
+++ b/arch/aarch64/meson.build
@@ -9,6 +9,7 @@ if target_architecture == 'aarch64'
 	target_arch_include += include_directories('include')
 endif
 
-if host_architecture == 'aarch64'
-	host_arch_deps += [arm64_arch_dep]
+if native_architecture == 'aarch64'
+	native_arch_deps += [arm64_arch_dep]
+	native_arch_include += include_directories('include')
 endif

--- a/arch/arm/meson.build
+++ b/arch/arm/meson.build
@@ -20,6 +20,7 @@ if target_architecture == 'arm'
 	target_arch_include += include_directories('include')
 endif
 
-if host_architecture == 'arm'
-	host_arch_deps += [arm_arch_dep]
+if native_architecture == 'arm'
+	native_arch_deps += [arm_arch_dep]
+	native_arch_include += include_directories('include')
 endif

--- a/arch/x86/meson.build
+++ b/arch/x86/meson.build
@@ -9,6 +9,7 @@ if target_architecture == 'x86'
 	target_arch_include += include_directories('include')
 endif
 
-if host_architecture == 'x86'
-	host_arch_deps += [x86_arch_dep]
+if native_architecture == 'x86'
+	native_arch_deps += [x86_arch_dep]
+	native_arch_include += include_directories('include')
 endif

--- a/arch/x86_64/meson.build
+++ b/arch/x86_64/meson.build
@@ -9,6 +9,7 @@ if target_architecture == 'x86_64'
 	target_arch_include += include_directories('include')
 endif
 
-if host_architecture == 'x86_64'
-	host_arch_deps += [x86_64_arch_dep]
+if native_architecture == 'x86_64'
+	native_arch_deps += [x86_64_arch_dep]
+	native_arch_include += include_directories('include')
 endif

--- a/meson.build
+++ b/meson.build
@@ -47,13 +47,14 @@ libc_system_includes = include_directories(
 subdir('build/architecture')
 
 target_arch_include = []
+native_arch_include = []
 target_arch_deps = []
-host_arch_deps = []
+native_arch_deps = []
 
 subdir('arch/' + target_architecture)
 
-if target_architecture != host_architecture
-	subdir('arch/' + host_architecture)
+if target_architecture != native_architecture
+	subdir('arch/' + native_architecture)
 endif
 
 #########################
@@ -82,7 +83,7 @@ libc_printf_dep = declare_dependency(
 printf_tests = executable('printf_test',
 	['printf/test/test_suite.cpp'],
 	cpp_args: ['-Wno-format', '-Wno-format-invalid-specifier', '-Wno-old-style-cast', '-Wno-missing-prototypes'],
-	include_directories: [include_directories('printf/test', is_system: true)],
+	include_directories: [include_directories('printf/test')],
 	native: true
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -273,7 +273,7 @@ libc_native = static_library(
 	libc_common_files + libc_native_files,
 	c_args: [stdlib_compiler_flags, gdtoa_compiler_flags, libc_native_compile_args, '-nostdinc'],
 	include_directories: [libc_includes, libc_system_includes],
-	dependencies: host_arch_deps,
+	dependencies: native_arch_deps,
 	pic: true,
 	native: true,
 )
@@ -285,31 +285,32 @@ libc_hosted = static_library(
 		libc_common_files + libc_native_files,
 		c_args: [stdlib_compiler_flags, gdtoa_compiler_flags, libc_host_compile_args, '-nostdinc'],
 		include_directories: [libc_includes, libc_system_includes],
-		dependencies: host_arch_deps,
+		dependencies: native_arch_deps,
 		pic: true
 )
 
 libc_dep = declare_dependency(
 	link_with: libc,
-	include_directories: [libc_system_includes],
+	include_directories: [libc_system_includes, target_arch_include],
 	compile_args: stdlib_compiler_flags,
 	dependencies: target_arch_deps,
 )
 
 libc_native_dep = declare_dependency(
 	link_with: libc_native,
-	include_directories: [libc_system_includes],
+	include_directories: [libc_system_includes, native_arch_include],
 	compile_args: stdlib_compiler_flags + native_stdlib_compiler_flags,
 	link_args: native_stdlib_link_flags,
-	dependencies: host_arch_deps,
+	dependencies: native_arch_deps,
 )
 
 libc_hosted_dep = declare_dependency(
 	link_with: libc_hosted,
-	include_directories: [libc_system_includes],
+	include_directories: [libc_system_includes, target_arch_include],
 	compile_args: stdlib_compiler_flags + native_stdlib_compiler_flags,
 	link_args: native_stdlib_link_flags,
-	dependencies: host_arch_deps,
+	dependencies: native_arch_deps,
 )
 
 libc_header_include = [libc_system_includes, target_arch_include]
+libc_native_header_include = [libc_system_includes, native_arch_include]


### PR DESCRIPTION
- Add a native_arch_include variable
- Add a native header include export
- Set the native_arch_include in each arch
- Rename host_arch_deps -> native_arch_deps
- Rebane host_architecutre -> native_archiecture
- add arch includes to dependencies
- Update build submodule