### PR TITLE
Update libc build archive steps

### DIFF
--- a/tools/Jenkinsfile
+++ b/tools/Jenkinsfile
@@ -73,6 +73,13 @@ pipeline
       {
         sh 'make docs'
       }
+      post
+      {
+        success
+        {
+          sh 'tar cf buildresults/documentation.tgz buildresults/doc/'
+        }
+      }
     }
     stage('CppCheck')
     {
@@ -122,7 +129,7 @@ pipeline
       steps
       {
         echo 'Archiving artifacts'
-        archiveArtifacts 'buildresults/**/*'
+        archiveArtifacts 'buildresults/documentation.tgz'
       }
       post
       {


### PR DESCRIPTION
- Create a zip archive of the generated documentation
- Archive only the generated documentaiton, not the buildresults
