### PR TITLE
Add build option to disable unimplemented APIs

### DIFF
--- a/include/locale.h
+++ b/include/locale.h
@@ -44,8 +44,10 @@ struct lconv
 	char int_n_sign_posn;
 };
 
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 char* setlocale(int, const char*);
 struct lconv* localeconv(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nl_types.h
+++ b/include/nl_types.h
@@ -11,9 +11,11 @@ extern "C" {
 typedef int nl_item;
 typedef void* nl_catd;
 
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 nl_catd catopen(const char*, int);
 char* catgets(nl_catd, int, int, const char*);
 int catclose(nl_catd);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/setjmp.h
+++ b/include/setjmp.h
@@ -15,14 +15,19 @@ typedef struct __jmp_buf_tag
 } jmp_buf[1];
 
 typedef jmp_buf sigjmp_buf;
+
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 int sigsetjmp(sigjmp_buf, int);
 void siglongjmp(sigjmp_buf, int) __attribute__((noreturn));
+#endif
 
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 int _setjmp(jmp_buf);
 int setjmp(jmp_buf);
 
 void _longjmp(jmp_buf, int) __attribute__((noreturn));
 void longjmp(jmp_buf, int) __attribute__((noreturn));
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -67,7 +67,14 @@ typedef struct __sFILE_fake FILE;
 int putchar(int c);
 int puts(const char*);
 
+#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+int asprintf(char**, const char*, ...);
+int vasprintf(char**, const char*, __isoc_va_list);
+#endif
+
 #pragma mark - Unsupported Functions -
+
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 
 int fseek(FILE*, long, int);
 long ftell(FILE*);
@@ -153,10 +160,6 @@ int swprintf(wchar_t* __restrict, size_t, const wchar_t* __restrict, ...);
 int vwprintf(const wchar_t* __restrict, __isoc_va_list);
 int vfwprintf(FILE* __restrict, const wchar_t* __restrict, __isoc_va_list);
 int vswprintf(wchar_t* __restrict, size_t, const wchar_t* __restrict, __isoc_va_list);
-
-#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-int asprintf(char**, const char*, ...);
-int vasprintf(char**, const char*, __isoc_va_list);
 #endif
 
 #ifdef __cplusplus

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -72,19 +72,25 @@ int at_quick_exit(void (*)(void));
 void quick_exit(int) __attribute__((noreturn));
 int cxa_atexit(void (*)(void*), void*, void*);
 
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 // Unsupported in bare metal environments:
 char* getenv(const char*);
+#endif
 
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 // Unsupported in bare metal environments:
 int system(const char*);
+#endif
 
 #pragma mark - Multibyte APIs -
 
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 int mblen(const char*, size_t);
 int mbtowc(wchar_t* __restrict, const char* __restrict, size_t);
 int wctomb(char*, wchar_t);
 size_t mbstowcs(wchar_t* __restrict, const char* __restrict, size_t);
 size_t wcstombs(char* __restrict, const wchar_t* __restrict, size_t);
+#endif
 
 #pragma mark - ascii-to-x -
 

--- a/include/time.h
+++ b/include/time.h
@@ -80,6 +80,9 @@ struct itimerspec
 
 #pragma mark - Functions -
 
+char* asctime(const struct tm*);
+
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 clock_t clock(void);
 time_t time(time_t*);
 double difftime(time_t, time_t);
@@ -87,16 +90,19 @@ time_t mktime(struct tm*);
 size_t strftime(char* __restrict, size_t, const char* __restrict, const struct tm* __restrict);
 struct tm* gmtime(const time_t*);
 struct tm* localtime(const time_t*);
-char* asctime(const struct tm*);
+
 char* ctime(const time_t*);
 
 int timespec_get(struct timespec*, int);
+#endif
 
 #if defined(_GNU_SOURCE) || defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) || \
 	defined(_BSD_SOURCE)
+char* asctime_r(const struct tm* __restrict, char* __restrict);
+
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 struct tm* gmtime_r(const time_t* __restrict, struct tm* __restrict);
 struct tm* localtime_r(const time_t* __restrict, struct tm* __restrict);
-char* asctime_r(const struct tm* __restrict, char* __restrict);
 char* ctime_r(const time_t*, char*);
 
 int nanosleep(const struct timespec*, struct timespec*);
@@ -114,19 +120,24 @@ int timer_gettime(timer_t, struct itimerspec*);
 int timer_getoverrun(timer_t);
 
 extern char* tzname[2];
+#endif // DISABLE_UNIMPLEMENTED_LIBC_APIS
 #endif
 
 #if defined(_XOPEN_SOURCE) || defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 char* strptime(const char* __restrict, const char* __restrict, struct tm* __restrict);
 extern int daylight;
 extern long timezone;
 extern int getdate_err;
 struct tm* getdate(const char*);
+#endif // DISABLE_UNIMPLEMENTED_LIBC_APIS
 #endif
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 int stime(const time_t*);
 time_t timegm(struct tm*);
+#endif // DISABLE_UNIMPLEMENTED_LIBC_APIS
 #endif
 
 #ifdef __cplusplus

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -20,9 +20,11 @@ typedef struct
 
 int wcwidth(wchar_t);
 int wcswidth(const wchar_t*, size_t);
+wchar_t* wcschr(const wchar_t*, wchar_t);
 
 #pragma mark - Unspported API -
 
+#ifndef DISABLE_UNIMPLEMENTED_LIBC_APIS
 wint_t btowc(int);
 int wctob(wint_t);
 
@@ -38,7 +40,6 @@ int wcsncmp(const wchar_t*, const wchar_t*, size_t);
 int wcscoll(const wchar_t*, const wchar_t*);
 size_t wcsxfrm(wchar_t* __restrict, const wchar_t* __restrict, size_t);
 
-wchar_t* wcschr(const wchar_t*, wchar_t);
 wchar_t* wcsrchr(const wchar_t*, wchar_t);
 
 size_t wcscspn(const wchar_t*, const wchar_t*);
@@ -92,6 +93,7 @@ int wcsncasecmp(const wchar_t*, const wchar_t*, size_t);
 struct tm;
 size_t wcsftime(wchar_t* __restrict, size_t, const wchar_t* __restrict,
 				const struct tm* __restrict);
+#endif
 
 #ifdef __cplusplus
 }

--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,10 @@ if get_option('enable-pedantic-error') == true
 	add_project_arguments('-pedantic-error', language : ['c', 'cpp'])
 endif
 
+if get_option('hide-unimplemented-libc-apis') == true
+	add_project_arguments('-DDISABLE_UNIMPLEMENTED_LIBC_APIS', language: ['c', 'cpp'])
+endif
+
 ############################
 # Process external modules #
 ############################

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('enable-werror', type: 'boolean', value: false, yield: true)
 option('enable-pedantic-error', type: 'boolean', value: false, yield: true)
+option('hide-unimplemented-libc-apis', type: 'boolean', value: false, yield: true)


### PR DESCRIPTION
We need unimplemented APIs defined to satisfy the libcpp build, even though we aren't using these functions.

A build option has been added to disable these unimplemented APIs for users who want to hide them from their programs. This does mean that you cannot use the library with libcpp, however.

Fixes #54