### PR TITLE
fix redefinition of SIZE_MAX on aarch64

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -276,7 +276,9 @@ typedef uint64_t uint_fast64_t;
 #define UINTMAX_MAX UINT64_MAX
 
 /*! Maximum value of object of size_t type */
+#ifndef SIZE_MAX
 #define SIZE_MAX UINT32_MAX
+#endif
 
 #if defined(__STDC_WANT_LIB_EXT1__) && __STDC_WANT_LIB_EXT1__ >= 1
 


### PR DESCRIPTION
## Description

Fixes re-declaration/warming for SIZE_MAX on aarch64 and other 64-bit targets.  I thought about adding `SIZE_MAX` to the "`__WORDSIZE` is 32 bits" `else` section but I was concerned about support for < 32 bit targets.

```
In file included from /home/jkent/Projects/fe/neoboot/deps/libc/printf/printf.c:34:
/home/jkent/Projects/fe/neoboot/deps/libc/include/stdint.h:279: warning: "SIZE_MAX" redefined
 #define SIZE_MAX UINT32_MAX
 
/home/jkent/Projects/fe/neoboot/deps/libc/include/stdint.h:249: note: this is the location of the previous definition
 #define SIZE_MAX UINT64_MAX
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Compilation.