### PR TITLE
Don't force pic build (fixes b_staticpic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you are interested in contributing to this project, please read the [`CONTRIB
 	2. [Getting the Source](#getting-the-source)
 	3. [Building](#building)
 		1. [Cross-compiling](#cross-compiling)
+		2. [Disabling Position Independent Code](#disabling-position-independent-code)
 	4. [Installation](#installation)
 	5. [Usage](#usage)
 		1. [Aligned Malloc](#aligned-malloc)
@@ -252,6 +253,14 @@ meson buildresults --cross-file build/cross/gcc/arm/gcc_arm_cortex-m4.txt
 Following that, you can run `make` (at the project root) or `ninja` (within the build output directory) to build the project.
 
 Tests will not be cross-compiled. They will be built for the native platform.
+
+#### Disabling Position Independent Code
+
+Position Independent Code (PIC) is enabled by default, but can be disabled during the Meson configuration stage by setting the built-in option `b_staticpic` to `false`:
+
+```
+meson buildresults -Db_staticpic=false
+```
 
 ### Installation
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -278,7 +278,6 @@ libprintf = static_library(
     ],
     include_directories: [libc_includes, libc_system_includes],
     dependencies: target_arch_deps,
-    pic: true
 )
 
 libprintf_native = static_library(
@@ -294,7 +293,6 @@ libprintf_native = static_library(
     ],
     include_directories: [libc_includes, libc_system_includes],
     dependencies: native_arch_deps,
-    pic: true,
     native: true,
 )
 
@@ -304,7 +302,6 @@ libc = static_library(
 	c_args: [stdlib_compiler_flags, gdtoa_compiler_flags, libc_host_compile_args, '-nostdinc'],
 	include_directories: [libc_includes, libc_system_includes],
 	dependencies: target_arch_deps,
-	pic: true,
 )
 
 # We don't build the stdio files for the native variant, as we rely on the
@@ -315,7 +312,6 @@ libc_native = static_library(
 	c_args: [stdlib_compiler_flags, gdtoa_compiler_flags, libc_native_compile_args, '-nostdinc'],
 	include_directories: [libc_includes, libc_system_includes],
 	dependencies: native_arch_deps,
-	pic: true,
 	native: true,
 )
 
@@ -327,7 +323,6 @@ libc_hosted = static_library(
 		c_args: [stdlib_compiler_flags, gdtoa_compiler_flags, libc_host_compile_args, '-nostdinc'],
 		include_directories: [libc_includes, libc_system_includes],
 		dependencies: target_arch_deps,
-		pic: true
 )
 
 ##########################


### PR DESCRIPTION
# Don't force pic build

## Description

Currently there is no way to disable pic build on master, because pic is forcefully enable in build files. This PR removes that and allows b_staticpic option to function correctly. b_staticpic seems to be enabled by default.

Also added readme entry for this option.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Built libc with b_staticpic set to true and false
