### PR TITLE
CRT fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Tests will not be cross-compiled. They will only be built for the native platfor
 
 **Full instructions for building the project, using alternate toolchains, and running supporting tooling are documented in [Embedded Artistry's Standardized Meson Build System](https://embeddedartistry.com/fieldatlas/embedded-artistrys-standardized-meson-build-system/) on our website.**
 
-#### Disabling Position Independent Code
+### Disabling Position Independent Code
 
 Position Independent Code (PIC) is enabled by default, but can be disabled during the Meson configuration stage by setting the built-in option `b_staticpic` to `false`:
 

--- a/src/crt/crt.c
+++ b/src/crt/crt.c
@@ -38,9 +38,9 @@ __attribute__((no_stack_protector)) void __libc_init_array(void)
 void __libc_fini_array(void)
 {
 	size_t count = (size_t)((uintptr_t)__fini_array_end - (uintptr_t)__fini_array_start);
-	for(size_t i = count - 1; i > 0; i--)
+	for(size_t i = count; i > 0; i--)
 	{
-		__fini_array_start[i]();
+		__fini_array_start[i-1]();
 	}
 }
 

--- a/src/crt/stack_protection.c
+++ b/src/crt/stack_protection.c
@@ -12,14 +12,14 @@
 #endif
 
 #ifdef DISABLE_STACK_CHK_GUARD_RUNTIME_CONFIG
-uintptr_t __stack_chk_guard = STACK_CHK_GUARD_VALUE;
+__attribute__((weak)) uintptr_t __stack_chk_guard = STACK_CHK_GUARD_VALUE;
 #else
 /** Stack check guard variable
  *
  * The value of this variable is used as a stack canary to detect
  * whether an overflow has occurred.
  */
-uintptr_t __stack_chk_guard = 0;
+__attribute__((weak)) uintptr_t __stack_chk_guard = 0;
 
 /*
  * Stack protection *must* be disabled for this function. In the case of

--- a/test/app/main.c
+++ b/test/app/main.c
@@ -7,3 +7,5 @@ int main(void)
 
 	return 0;
 }
+
+void _putchar(char character) {}


### PR DESCRIPTION
# Fixes to CRT

## Description

Fixed a bug in __libc_fini_array, which prevented the first element from being called.
Added attribute 'weak' to __stack_chk_guard in order to enable possibility of external implementation.
Added missing function to  test app (otherwise it doesn't compile).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Compiled everything with gcc-9
