### PR TITLE
Disable builtins by default.

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,10 @@
-option('hide-unimplemented-libc-apis', type: 'boolean', value: false, 
-    description: 'Make unimplemented libc functions invisible to the compiler.', 
+option('hide-unimplemented-libc-apis', type: 'boolean', value: false,
+    description: 'Make unimplemented libc functions invisible to the compiler.',
     yield: true)
-option('enable-gnu-extensions', type: 'boolean', value: false, 
-    description: 'Enable GNU libc extensions.', 
+option('enable-gnu-extensions', type: 'boolean', value: false,
+    description: 'Enable GNU libc extensions.',
     yield: true)
-option('disable-builtins', type: 'boolean', value: false,
+option('disable-builtins', type: 'boolean', value: true,
     description: 'Tell the compiler not to generate builtin functions.',
     yield: true)
 option('stack-canary-value', type: 'string', value: '',


### PR DESCRIPTION
When optimizations are enabled and compiler builtins are used, GCC can generate problematic code that can result in a segmentation fault or infinite loop in the test programs. From our investigation, this is related to the _Nonnull attribute's use in the compiler-builtins.