### PR TITLE
Fix `DEBUG=1` mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ DEBUG ?= 0
 SANITIZER ?= none
 INTERNAL_OPTIONS =
 
+ifeq ($(DISABLE_BUILTINS),1)
+	INTERNAL_OPTIONS += -Ddisable-builtins=true
+endif
+
 ifeq ($(LTO),1)
 	INTERNAL_OPTIONS += -Db_lto=true -Ddisable-builtins=true
 endif
@@ -38,7 +42,7 @@ ifneq ($(NATIVE),)
 endif
 
 ifeq ($(DEBUG),1)
-	INTERNAL_OPTIONS += '-Ddebug=true -Doptimization=g'
+	INTERNAL_OPTIONS += -Ddebug=true -Doptimization=g
 endif
 
 ifneq ($(SANITIZER),none)


### PR DESCRIPTION
 #### Summary
On my ubuntu 18.04 image, enabling the `DEBUG=1` flag to debug the
library fails to build with this error message:

```plaintext
meson.build:1:0: ERROR: Value true -Doptimization=g is not boolean (true or false).
```

Removing the single quotes enables the build to proceed!

 #### Testing
This patch doesn't add a build step to verify the `DEBUG=1` mode is
still working, so just tested locally!