### PR TITLE
Address pointer math bug in crt.c

### DIFF
--- a/docs/architecture/decisions/0002-crt-initialization-symbol-types.md
+++ b/docs/architecture/decisions/0002-crt-initialization-symbol-types.md
@@ -1,0 +1,122 @@
+# 2. CRT Initialization Symbol Types
+
+Date: 2020-10-15
+
+## Status
+
+Accepted
+
+## Context
+
+We found a bug in the `__libc_init_array()` and `__libc_fini_array()` functions - we were doing math on uintptr_t, which generated 4x or 8x the number of entries as was actually present. This might result in no noticeable issue, or it might crash your system - depends on what functions get called in the bonus round!
+
+When implementing the tests, we had trouble with the form of `* []` (array of function pointers), so we changed the types to `**`. This gave us the behavior we wanted, enabling the testing to check the logic for these functions on macOS.
+
+```
+extern void (**__preinit_array_start)(void) __attribute__((weak));
+extern void (**__preinit_array_end)(void) __attribute__((weak));
+extern void (**__init_array_start)(void) __attribute__((weak));
+extern void (**__init_array_end)(void) __attribute__((weak));
+extern void (**__fini_array_start)(void) __attribute__((weak));
+extern void (**__fini_array_end)(void) __attribute__((weak));
+
+// Currently these tests only run on OS X
+__attribute__((section("__DATA,.preinit_array"))) void (**__preinit_array_start)(void) = preinit_call_list;
+__attribute__((section("__DATA,.preinit_array"))) void (**__preinit_array_end)(void) = &preinit_call_list[1];
+__attribute__((section("__DATA,.init_array"))) void (**__init_array_start)(void) = init_call_list;
+__attribute__((section("__DATA,.init_array"))) void (**__init_array_end)(void) = &init_call_list[2];
+__attribute__((section("__DATA,.fini_array")))void (**__fini_array_start)(void)  = fini_call_list;
+__attribute__((section("__DATA,.fini_array")))void (**__fini_array_end)(void) = &fini_call_list[3];
+```
+
+Example output:
+
+```
+[0/1] Running all tests.
+1/3 printf_tests      OK             0.34s
+2/3 libc_tests        OK             0.55s
+3/3 stackprotect_test EXPECTEDFAIL   0.01s
+
+
+Ok:                 2
+Expected Fail:      1
+Fail:               0
+Unexpected Pass:    0
+Skipped:            0
+Timeout:            0
+
+preinit array: 00000001029600C0, end: 00000001029600C0
+init array: 0000000102960080, end: 0000000102960080
+fini array: 00000001029600A0, end: 00000001029600B8
+Count: 0, preinit_array_end: 00000001029600C0, preinit_array_start: 00000001029600C0, CTR_TO_PTR_ADJUST: 3, count calculated: 0
+```
+
+Using a `**` works on macOS when testing, but does not work on device - we need to adjust our logic in that case to take the address of the symbols (e.g., `&__preinit_array_end`). 
+
+```
+(gdb) n
+52        count = (size_t)(((uintptr_t)__init_array_end - (uintptr_t)__init_array_start) >>
+(gdb) n
+54        for(size_t i = 0; i < count; i++)
+(gdb) p count
+$2 = 100662561
+(gdb) p __init_array_end
+$3 = (void (**)(void)) 0x200001ec <__cxa_unexpected_handler>
+(gdb) p __init_array_start
+$4 = (void (**)(void)) 0x8000d65
+     <_GLOBAL__sub_I_cxa_default_handlers.cpp(void)>
+(gdb) p &__init_array_start
+$5 = (void (***)(void)) 0x20000044
+(gdb) p &__init_array_end
+$6 = (void (***)(void)) 0x20000048
+(gdb) p __init_array_start[0]
+$7 = (void (*)(void)) 0xfff64fb5
+(gdb) p __preinit_array_start
+$9 = (void (**)(void)) 0x8000d65 <_GLOBAL__sub_I_cxa_default_handlers.cpp(void)>
+(gdb) p &__preinit_array_start
+$10 = (void (***)(void)) 0x20000044
+```
+
+However, taking the address of these symbols makes the test fail again!
+
+```
+<testsuites>
+  <testsuite name="crt_tests" time="0.000" tests="2" failures="2" errors="0" skipped="0" >
+    <testcase name="check_crt_init_routines" time="0.000" >
+      <failure><![CDATA[0x1 != 0x2
+../test/crt/crt_init_array.c:80: error: Failure!]]></failure>
+    </testcase>
+    <testcase name="check_crt_fini_routines" time="0.000" >
+      <failure><![CDATA[0x1 != 0x3
+../test/crt/crt_init_array.c:88: error: Failure!]]></failure>
+    </testcase>
+  </testsuite>
+```
+
+## Decision
+
+Not knowing whether this is a Clang or OS X specific behavior, we'll just use an `#ifdef` to select the proper form when testing. This will ensure that current devices work as-is, and our testing form is only used when building libc tests on macOS. If this changes (e.g., we find out it's actually predicated on `__APPLE__`), we can adjust as-is.
+
+```
+#ifdef ENABLE_CRT_TESTING
+// Note that this might actually be #if __APPLE__, but we only
+// Use this file on OS X for testing purposes.
+extern void (**__preinit_array_start)(void) __attribute__((weak));
+extern void (**__preinit_array_end)(void) __attribute__((weak));
+extern void (**__init_array_start)(void) __attribute__((weak));
+extern void (**__init_array_end)(void) __attribute__((weak));
+extern void (**__fini_array_start)(void) __attribute__((weak));
+extern void (**__fini_array_end)(void) __attribute__((weak));
+#else
+extern void (*__preinit_array_start[])(void) __attribute__((weak));
+extern void (*__preinit_array_end[])(void) __attribute__((weak));
+extern void (*__init_array_start[])(void) __attribute__((weak));
+extern void (*__init_array_end[])(void) __attribute__((weak));
+extern void (*__fini_array_start[])(void) __attribute__((weak));
+extern void (*__fini_array_end[])(void) __attribute__((weak));
+#endif
+```
+
+## Consequences
+
+There is still the possibility of incorrect behavior with other compilers/systems.

--- a/src/crt/crt.c
+++ b/src/crt/crt.c
@@ -5,12 +5,23 @@
 
 extern int __bss_start__;
 extern int __bss_end__;
+#ifdef ENABLE_CRT_TESTING
+// Note that this might actually be #if __APPLE__, but we only
+// Use this file on OS X for testing purposes.
 extern void (**__preinit_array_start)(void) __attribute__((weak));
 extern void (**__preinit_array_end)(void) __attribute__((weak));
 extern void (**__init_array_start)(void) __attribute__((weak));
 extern void (**__init_array_end)(void) __attribute__((weak));
 extern void (**__fini_array_start)(void) __attribute__((weak));
 extern void (**__fini_array_end)(void) __attribute__((weak));
+#else
+extern void (*__preinit_array_start[])(void) __attribute__((weak));
+extern void (*__preinit_array_end[])(void) __attribute__((weak));
+extern void (*__init_array_start[])(void) __attribute__((weak));
+extern void (*__init_array_end[])(void) __attribute__((weak));
+extern void (*__fini_array_start[])(void) __attribute__((weak));
+extern void (*__fini_array_end[])(void) __attribute__((weak));
+#endif
 extern int main();
 
 __attribute__((weak)) int entry(void)

--- a/src/crt/crt.c
+++ b/src/crt/crt.c
@@ -5,12 +5,12 @@
 
 extern int __bss_start__;
 extern int __bss_end__;
-extern void (*__preinit_array_start[])(void) __attribute__((weak));
-extern void (*__preinit_array_end[])(void) __attribute__((weak));
-extern void (*__init_array_start[])(void) __attribute__((weak));
-extern void (*__init_array_end[])(void) __attribute__((weak));
-extern void (*__fini_array_start[])(void) __attribute__((weak));
-extern void (*__fini_array_end[])(void) __attribute__((weak));
+extern void (**__preinit_array_start)(void) __attribute__((weak));
+extern void (**__preinit_array_end)(void) __attribute__((weak));
+extern void (**__init_array_start)(void) __attribute__((weak));
+extern void (**__init_array_end)(void) __attribute__((weak));
+extern void (**__fini_array_start)(void) __attribute__((weak));
+extern void (**__fini_array_end)(void) __attribute__((weak));
 extern int main();
 
 __attribute__((weak)) int entry(void)
@@ -19,16 +19,38 @@ __attribute__((weak)) int entry(void)
 	return main();
 }
 
+/** Pointer Count Decimator
+ *
+ * We can't do math on void*, and we want to have something that works
+ * for 16-bit, 32-bit, and 64-bit systems. So we will be calculating "counts"
+ * based on the raw bytes, and converting that value into the number of "words"
+ * or "registers" or "pointers" that will be loaded into the arrays for processing.
+ *
+ * We'll define a shift offset that can be used to convert the values, rather
+ * than doing a straight division.
+ */
+#if UINTPTR_MAX == 0xFFFFu
+#define COUNT_TO_PTR_ADJUSTMENT 1U
+#elif UINTPTR_MAX == 0xFFFFFFFFu
+#define COUNT_TO_PTR_ADJUSTMENT 2U
+#elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+#define COUNT_TO_PTR_ADJUSTMENT 3U
+#else
+#error Processor pointer size is unsupported!
+#endif
+
 // This function may call another function which changes __stack_chk_guard
 __attribute__((no_stack_protector)) void __libc_init_array(void)
 {
-	size_t count = (size_t)((uintptr_t)__preinit_array_end - (uintptr_t)__preinit_array_start);
+	size_t count = (size_t)(((uintptr_t)__preinit_array_end - (uintptr_t)__preinit_array_start) >>
+							COUNT_TO_PTR_ADJUSTMENT);
 	for(size_t i = 0; i < count; i++)
 	{
 		__preinit_array_start[i]();
 	}
 
-	count = (size_t)((uintptr_t)__init_array_end - (uintptr_t)__init_array_start);
+	count = (size_t)(((uintptr_t)__init_array_end - (uintptr_t)__init_array_start) >>
+					 COUNT_TO_PTR_ADJUSTMENT);
 	for(size_t i = 0; i < count; i++)
 	{
 		__init_array_start[i]();
@@ -37,7 +59,8 @@ __attribute__((no_stack_protector)) void __libc_init_array(void)
 
 void __libc_fini_array(void)
 {
-	size_t count = (size_t)((uintptr_t)__fini_array_end - (uintptr_t)__fini_array_start);
+	size_t count = (size_t)(((uintptr_t)__fini_array_end - (uintptr_t)__fini_array_start) >>
+							COUNT_TO_PTR_ADJUSTMENT);
 	for(size_t i = count; i > 0; i--)
 	{
 		__fini_array_start[i - 1]();

--- a/src/meson.build
+++ b/src/meson.build
@@ -74,6 +74,10 @@ crt_files = files(
 	'crt/stack_protection.c'
 )
 
+crt_files_for_test = files(
+	'crt/crt.c',
+)
+
 stack_protection_file = files('crt/stack_protection.c')
 
 ctype_files = files(

--- a/test/crt/crt_init_array.c
+++ b/test/crt/crt_init_array.c
@@ -1,0 +1,100 @@
+
+/*
+ * Copyright © 2020 Embedded Artistry LLC.
+ * License: MIT. See LICENSE file for details.
+ */
+
+#include "crt_tests.h"
+#include <crt.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+// Cmocka needs these
+// clang-format off
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+// clang-format on
+
+static volatile bool preinit_was_called = false;
+static volatile bool preinit_was_not_called = true;
+static volatile int init_was_called = 0;
+static volatile bool init_was_not_called = true;
+static volatile int fini_was_called = 0;
+static volatile bool fini_was_not_called = true;
+
+static void preinit_should_be_called(void)
+{
+	preinit_was_called = true;
+}
+
+static void preinit_should_not_be_called(void)
+{
+	preinit_was_not_called = false;
+}
+
+static void init_should_be_called(void)
+{
+	init_was_called = init_was_called + 1;
+}
+
+static void init_should_not_be_called(void)
+{
+	init_was_not_called = false;
+}
+
+static void fini_should_be_called(void)
+{
+	fini_was_called = fini_was_called + 1;
+}
+
+static void fini_should_not_be_called(void)
+{
+	fini_was_not_called = false;
+}
+
+static void (*preinit_call_list[2])(void) = {preinit_should_be_called,
+											 preinit_should_not_be_called};
+void (*init_call_list[])(void) = {init_should_be_called, init_should_be_called,
+								  init_should_not_be_called};
+void (*fini_call_list[])(void) = {fini_should_be_called, fini_should_be_called,
+								  fini_should_be_called, fini_should_not_be_called};
+
+// Currently these tests only run on OS X
+__attribute__((section("__DATA,.preinit_array"))) void (**__preinit_array_start)(void) =
+	preinit_call_list;
+__attribute__((section("__DATA,.preinit_array"))) void (**__preinit_array_end)(void) =
+	&preinit_call_list[1];
+__attribute__((section("__DATA,.init_array"))) void (**__init_array_start)(void) = init_call_list;
+__attribute__((section("__DATA,.init_array"))) void (**__init_array_end)(void) = &init_call_list[2];
+__attribute__((section("__DATA,.fini_array"))) void (**__fini_array_start)(void) = fini_call_list;
+__attribute__((section("__DATA,.fini_array"))) void (**__fini_array_end)(void) = &fini_call_list[3];
+
+static void check_crt_init_routines(void** state)
+{
+	__libc_init_array();
+
+	assert_true(preinit_was_called);
+	assert_true(preinit_was_not_called);
+	assert_int_equal(init_was_called, 2);
+	assert_true(init_was_not_called);
+}
+
+static void check_crt_fini_routines(void** state)
+{
+	__libc_fini_array();
+
+	assert_int_equal(fini_was_called, 3);
+	assert_true(fini_was_not_called);
+}
+
+int crt_array_test_suite(void)
+{
+	const struct CMUnitTest crt_tests[] = {
+		cmocka_unit_test(check_crt_init_routines),
+		cmocka_unit_test(check_crt_fini_routines),
+	};
+
+	return cmocka_run_group_tests(crt_tests, NULL, NULL);
+}

--- a/test/crt/crt_tests.c
+++ b/test/crt/crt_tests.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020 Embedded Artistry LLC.
+ * License: MIT. See LICENSE file for details.
+ */
+#include "crt_tests.h"
+#include <stdlib.h>
+#include <tests.h>
+
+// Cmocka needs these
+// clang-format off
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <cmocka.h>
+// clang-format on
+
+int crt_tests(void)
+{
+	int overall_result = 0;
+
+	if(0 != crt_array_test_suite())
+	{
+		overall_result = -1;
+	}
+
+	return overall_result;
+}

--- a/test/crt/crt_tests.h
+++ b/test/crt/crt_tests.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright © 2020 Embedded Artistry LLC.
+ * License: MIT. See LICENSE file for details.
+ */
+
+#ifndef CRT_TESTS_H_
+#define CRT_TESTS_H_
+
+int crt_array_test_suite(void);
+
+#endif // CRT_TESTS_H_

--- a/test/main.c
+++ b/test/main.c
@@ -23,6 +23,9 @@ int main(void)
 	overall_result |= ctype_tests();
 	overall_result |= string_tests();
 	overall_result |= stdlib_tests();
+#ifdef ENABLE_CRT_TESTING
+	overall_result |= crt_tests();
+#endif
 
 	return overall_result;
 }

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,6 +2,8 @@
 
 libc_test_files = files(
 	'main.c',
+	'crt/crt_init_array.c',
+	'crt/crt_tests.c',
 	'ctype/ctype_tests.c',
 	'ctype/isalnum.c',
 	'ctype/isalpha.c',
@@ -86,6 +88,19 @@ if disable_builtins == false
 	libc_test_flags += '-DBUILTINS_ARE_ENABLED'
 endif
 
+#################################
+# Enable CRT Testing if on OS X #
+#################################
+
+if build_machine.system() == 'darwin'
+	crt_test_dep = declare_dependency(
+		sources: crt_files_for_test,
+		compile_args: '-DENABLE_CRT_TESTING'
+	)
+else
+	crt_test_dep = []
+endif
+
 ###############
 # Test Target #
 ###############
@@ -93,8 +108,14 @@ endif
 ## Subproject Example
 libc_tests = executable('libc_test',
 	libc_test_files,
-	dependencies: [cmocka_native_dep, libc_hosted_native_dep],
-	link_args: native_map_file.format(meson.current_build_dir() + '/libc_test'),
+	dependencies: [
+		cmocka_native_dep,
+		libc_hosted_native_dep,
+		crt_test_dep,
+	],
+	link_args: [
+		native_map_file.format(meson.current_build_dir() + '/libc_test'),
+	],
 	c_args: libc_test_flags,
 	native: true,
 	build_by_default: meson.is_subproject() == false,

--- a/test/tests.h
+++ b/test/tests.h
@@ -4,5 +4,6 @@
 int string_tests(void);
 int ctype_tests(void);
 int stdlib_tests(void);
+int crt_tests(void);
 
 #endif // TEST_H_


### PR DESCRIPTION
Originally we used void* for calculations, but this is a GCC extension. I switched to uintptr_t, but then I was doing actual math. This meant that the startup code was calculating values incorrectly, and running 4x the actual functions that were supposed to be run.

For portability reasons, we keep the uintptr math, and then we convert back to the actual count of functions using shift operations.
