### PR TITLE
Simplify Implementation to just operate on function pointers …

### DIFF
--- a/src/crt/crt.c
+++ b/src/crt/crt.c
@@ -30,38 +30,16 @@ __attribute__((weak)) int entry(void)
 	return main();
 }
 
-/** Pointer Count Decimator
- *
- * We can't do math on void*, and we want to have something that works
- * for 16-bit, 32-bit, and 64-bit systems. So we will be calculating "counts"
- * based on the raw bytes, and converting that value into the number of "words"
- * or "registers" or "pointers" that will be loaded into the arrays for processing.
- *
- * We'll define a shift offset that can be used to convert the values, rather
- * than doing a straight division.
- */
-#if UINTPTR_MAX == 0xFFFFu
-#define COUNT_TO_PTR_ADJUSTMENT 1U
-#elif UINTPTR_MAX == 0xFFFFFFFFu
-#define COUNT_TO_PTR_ADJUSTMENT 2U
-#elif UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
-#define COUNT_TO_PTR_ADJUSTMENT 3U
-#else
-#error Processor pointer size is unsupported!
-#endif
-
 // This function may call another function which changes __stack_chk_guard
 __attribute__((no_stack_protector)) void __libc_init_array(void)
 {
-	size_t count = (size_t)(((uintptr_t)__preinit_array_end - (uintptr_t)__preinit_array_start) >>
-							COUNT_TO_PTR_ADJUSTMENT);
+	size_t count = (size_t)(__preinit_array_end - __preinit_array_start);
 	for(size_t i = 0; i < count; i++)
 	{
 		__preinit_array_start[i]();
 	}
 
-	count = (size_t)(((uintptr_t)__init_array_end - (uintptr_t)__init_array_start) >>
-					 COUNT_TO_PTR_ADJUSTMENT);
+	count = (size_t)(__init_array_end - __init_array_start);
 	for(size_t i = 0; i < count; i++)
 	{
 		__init_array_start[i]();
@@ -70,8 +48,7 @@ __attribute__((no_stack_protector)) void __libc_init_array(void)
 
 void __libc_fini_array(void)
 {
-	size_t count = (size_t)(((uintptr_t)__fini_array_end - (uintptr_t)__fini_array_start) >>
-							COUNT_TO_PTR_ADJUSTMENT);
+	size_t count = (size_t)(__fini_array_end - __fini_array_start);
 	for(size_t i = count; i > 0; i--)
 	{
 		__fini_array_start[i - 1]();

--- a/test/crt/crt_init_array.c
+++ b/test/crt/crt_init_array.c
@@ -54,12 +54,11 @@ static void fini_should_not_be_called(void)
 	fini_was_not_called = false;
 }
 
-static void (*preinit_call_list[2])(void) = {preinit_should_be_called,
-											 preinit_should_not_be_called};
-void (*init_call_list[])(void) = {init_should_be_called, init_should_be_called,
-								  init_should_not_be_called};
-void (*fini_call_list[])(void) = {fini_should_be_called, fini_should_be_called,
-								  fini_should_be_called, fini_should_not_be_called};
+static void (*preinit_call_list[])(void) = {preinit_should_be_called, preinit_should_not_be_called};
+static void (*init_call_list[])(void) = {init_should_be_called, init_should_be_called,
+										 init_should_not_be_called};
+static void (*fini_call_list[])(void) = {fini_should_be_called, fini_should_be_called,
+										 fini_should_be_called, fini_should_not_be_called};
 
 // Currently these tests only run on OS X
 __attribute__((section("__DATA,.preinit_array"))) void (**__preinit_array_start)(void) =


### PR DESCRIPTION
...  instead of converting to integers and decimating. Upon reflecting, I don't know why we needed all that complication.