### PR TITLE
Fix endianness declarations for ARM platform

### DIFF
--- a/arch/arm/include/_endian.h
+++ b/arch/arm/include/_endian.h
@@ -2,9 +2,9 @@
 #define __ARM_MACHINE_ENDIAN_H_
 
 #ifdef __ARMEB__
-#define __BYTE_ORDER _BIG_ENDIAN
+#define __BYTE_ORDER __BIG_ENDIAN
 #else
-#define __BYTE_ORDER _LITTLE_ENDIAN
+#define __BYTE_ORDER __LITTLE_ENDIAN
 #endif //__ARMEB__
 
 #endif //__ARM_MACHINE_ENDIAN_H_


### PR DESCRIPTION
# Pull Request Template

## Description

The ARM platform references `_LITTLE_ENDIAN` and `_BIG_ENDIAN` instead of `__LITTLE_ENDIAN` and `__BIG_ENDIAN` (which are what is defined in endian.h and used for other platforms). Because the comparison performed in endian.h simply checks whether `__BYTE_ORDER == __LITTLE_ENDIAN`, this means that ARM platforms are treated as big-endian regardless of actual endianness.

This PR corrects the declarations to use the correct number of underscores, allowing little-endian ARM platforms to be correctly recognized as little-endian.

Please let me know if you believe I've misunderstood something or should have suggested a different fix for this problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added this assertion: `assert(htole32(123) == 123);` to my project on a little-endian ARM platform. Upon running the code, it asserted. After applying this change, it no longer asserted.

**Test Configuration**:
* Project version/commit: embeddedartistry/libc version bfa3d49a50581e59a5200ae5060c17207c3b63bc
* Hardware: QEMU '-M virt' platform
* Toolchain: debian gcc-arm-none-eabi package, version 15:7-2018-q2-6
* SDK: custom independent build environment not incorporating any embeddedartistry/libc build scripts

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ -- not relevant
- [ ] ~~I have made corresponding changes to the documentation~~ -- not relevant
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works -- I would prefer not to write test cases for a two-character typo fix at the moment. If this is really essential, I will wait until I have spare time to do that and resubmit then.
- [ ] ~~New and existing unit tests pass locally with my changes~~ -- not relevant
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ -- not relevant
