### PR TITLE
Add unittests for memmove()

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The following unit tests need to be added:
 * `div`, `ldiv`
 * `realloc`
 * `rand` family
-* `memmove`
 
 These are not implemented by may be added in the future:
 
@@ -264,7 +263,7 @@ If you don't use `meson` for your project, the best method to use this project i
 Example linker flags:
 
 ```
--Lpath/to/libc.a -lc 
+-Lpath/to/libc.a -lc
 ```
 
 If you're using `meson`, you can use `libc` as a subproject. Place it into your subproject directory of choice and add a `subproject` statement:

--- a/test/string/memmove.c
+++ b/test/string/memmove.c
@@ -4,6 +4,7 @@
  */
 
 #include "string_tests.h"
+#include <stdlib.h>
 #include <string.h>
 
 // Cmocka needs these
@@ -14,18 +15,95 @@
 #include <cmocka.h>
 // clang-format on
 
-static void memmove_test(void** state)
+struct test_memmove_data {
+	char template[64];
+	char buf[64];
+};
+
+static void fill_buffer(char* buf, size_t size, char start_value, char end_value)
 {
-	// TODO: "Memmove tests need to be implemented"
+	size_t i;
+	for (i=0; i< size; ++i)
+	{
+		buf[i] = (start_value + i) % (end_value - start_value + 1);
+	}
+}
+
+int setup_test(void **state)
+{
+	struct test_memmove_data* md = malloc(sizeof(struct test_memmove_data));
+	if (!md)
+	{
+		return -1;
+	}
+	fill_buffer(md->template, sizeof(md->template), 'A', 'Z');
+	memcpy(md->buf, md->template, sizeof(md->buf));
+	*state = md;
+	return 0;
+}
+
+int teardown_test(void **state)
+{
+	struct test_memmove_data *md = *state;
+	free(md);
+	return 0;
+}
+
+static void memmove_test_lower_to_higher(void** state)
+{
+	struct test_memmove_data* md = *state;
+	char* p;
+	size_t offset = 20;
+	size_t len = sizeof(md->buf) - offset;
+	p = memmove(md->buf+offset, md->buf, len);
+	assert_ptr_equal(p, md->buf+offset);
+	assert_memory_equal(md->buf+offset, md->template, len);
+	assert_memory_equal(md->buf, md->template, offset);
 	return;
 }
 
+static void memmove_test_higher_to_lower(void** state)
+{
+	struct test_memmove_data* md = *state;
+	char* p;
+	size_t offset = 20;
+	size_t len = sizeof(md->buf) - offset;
+	p = memmove(md->buf, md->buf+offset, len);
+	assert_ptr_equal(p, md->buf);
+	assert_memory_equal(md->buf, md->template+offset, len);
+	assert_memory_equal(md->buf+len, md->template+len, offset);
+	return;
+}
+
+static void memmove_test_zero_size(void **state)
+{
+	struct test_memmove_data* md = *state;
+	char* p;
+	size_t offset = 30;
+	p = memmove(md->buf+offset, md->buf, 0);
+	assert_ptr_equal(p, md->buf+offset);
+	assert_memory_equal(md->buf, md->template, sizeof(md->template));
+	return;
+}
+
+static void memmove_test_copy_to_itself(void **state)
+{
+	struct test_memmove_data* md = *state;
+	char* p;
+	p = memmove(md->buf, md->buf, sizeof(md->buf));
+	assert_ptr_equal(p, md->buf);
+	assert_memory_equal(md->buf, md->template, sizeof(md->template));
+	return;
+}
 #pragma mark - Public Functions -
 
 int memmove_tests(void)
 {
 	const struct CMUnitTest memmove_tests[] = {
-		cmocka_unit_test(memmove_test),
+		cmocka_unit_test_setup_teardown(memmove_test_lower_to_higher, setup_test, teardown_test),
+		cmocka_unit_test_setup_teardown(memmove_test_higher_to_lower, setup_test, teardown_test),
+		cmocka_unit_test_setup_teardown(memmove_test_zero_size, setup_test, teardown_test),
+		cmocka_unit_test_setup_teardown(memmove_test_copy_to_itself, setup_test, teardown_test),
 	};
 
 	return cmocka_run_group_tests(memmove_tests, NULL, NULL);


### PR DESCRIPTION
The approach taken here is relying quite a bit on the corresponding memmove tests in the coreboot [repo](https://github.com/ElyesH/coreboot). I liked this setup/teardown approach as it reduced the boilerplate of manually restoring the buffer in between runs. But if it's a too deviant change from the other unit tests just let me know. 

Fixes # 184
