### PR TITLE
remove redundant if statement in puts.c

### DIFF
--- a/src/stdio/puts.c
+++ b/src/stdio/puts.c
@@ -2,7 +2,7 @@
 
 int puts(const char* str)
 {
-	int r = 0;
+	int r = 1;
 
 	for(const char* c = str; *c != 0; c++)
 	{
@@ -10,12 +10,12 @@ int puts(const char* str)
 		r++;
 	}
 
-	// puts adds a newline
-	if(r)
+	if(r == 1)
 	{
-		putchar('\n');
-		r++;
+		return EOF;
 	}
 
-	return r ? r : EOF;
+	// puts adds a newline
+	putchar('\n');
+	return r;
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Removes a redundant if statement in puts. 

Doesn't fix anything.

## Type of change

Simplification

## How Has This Been Tested?

Compiling with just puts.c
```c
#include "puts.c"

int main() {
	return puts( "hello" );
}
```
returns `6` which is correct and
```c
#include "puts.c"

int main() {
	return puts( "" ) == EOF;
}
```
returns `1` which is correct
these tests for every possible outcome